### PR TITLE
DataTable: defaultSort has no effect #23

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cuba-platform/react",
-  "version": "0.3.1-dev.1",
+  "version": "0.3.1-dev.2",
   "description": "CUBA Platform utilities and components for React",
   "main": "dist/index.js",
   "module": "dist/index.esm.js",

--- a/src/ui/table/DataTable.tsx
+++ b/src/ui/table/DataTable.tsx
@@ -34,7 +34,6 @@ export interface DataTableProps<E> extends MainStoreInjected {
    */
   canSelectRowByClick?: boolean,
   buttons?: JSX.Element[],
-  defaultSort: string,
   tableProps?: TableProps<E>,
   columnProps?: ColumnProps<E>,
 }
@@ -51,6 +50,7 @@ export class DataTable<E> extends React.Component<DataTableProps<E>> {
   firstLoad: boolean = true;
   customFilters: Map<string, React.Component<DataTableCustomFilterProps>> =
     new Map<string, React.Component<DataTableCustomFilterProps>>();
+  defaultSort: string | undefined;
 
   constructor(props: DataTableProps<E>) {
     super(props);
@@ -58,6 +58,8 @@ export class DataTable<E> extends React.Component<DataTableProps<E>> {
     if (this.props.dataCollection.filter) {
       this.tableFilters = entityFilterToTableFilters(this.props.dataCollection.filter);
     }
+
+    this.defaultSort = this.props.dataCollection.sort;
   }
 
   static defaultProps = {
@@ -158,7 +160,7 @@ export class DataTable<E> extends React.Component<DataTableProps<E>> {
       pagination,
       filters: tableFilters,
       sorter,
-      defaultSort: this.props.defaultSort,
+      defaultSort: this.defaultSort,
       fields: this.props.fields,
       mainStore: this.props.mainStore!,
       dataCollection: this.props.dataCollection

--- a/src/ui/table/DataTableHelpers.tsx
+++ b/src/ui/table/DataTableHelpers.tsx
@@ -340,7 +340,7 @@ export function setFilters<E>(
  * if by the '-' character then descending. If there is no special character before the property name, then ascending sort will be used.
  * @param dataCollection
  */
-export function setSorter<E>(sorter: SorterResult<E>, defaultSort: string, dataCollection: DataCollectionStore<E>) {
+export function setSorter<E>(sorter: SorterResult<E>, defaultSort: string | undefined, dataCollection: DataCollectionStore<E>) {
   if (sorter && sorter.order) {
     const sortOrderPrefix: string = (sorter.order === 'descend') ? '-' : '+';
 
@@ -380,7 +380,7 @@ export interface TableChangeDTO<E> {
   pagination: PaginationConfig,
   filters: Record<string, string[]>,
   sorter: SorterResult<E>,
-  defaultSort: string,
+  defaultSort: string | undefined,
   fields: string[],
   mainStore: MainStore,
   dataCollection: DataCollectionStore<E>,


### PR DESCRIPTION
defaultSort prop is removed.
Default sorting is now determined by dataCollection.sort.